### PR TITLE
Expression functions for Vega-Lite selection predicates

### DIFF
--- a/src/DataScope.js
+++ b/src/DataScope.js
@@ -2,6 +2,10 @@ import {entry, ref, keyFieldRef, aggrField, sortKey} from './util';
 import {Aggregate, Collect} from './transforms';
 import {isString} from 'vega-util';
 
+export var INDEX  = 'index';
+export var LOOKUP = 'lookup';
+export var INDEX_TYPES = [INDEX, LOOKUP];
+
 export default function DataScope(scope, input, output, values, aggr) {
   this.scope = scope; // parent scope object
   this.input = input;   // first operator in pipeline (tuple input)
@@ -12,7 +16,8 @@ export default function DataScope(scope, input, output, values, aggr) {
   this.aggregate = aggr;
 
   // lookup table of field indices
-  this.index = {};
+  this.lookup = {};
+  this.index  = {};
 }
 
 DataScope.fromEntries = function(scope, entries) {
@@ -103,7 +108,7 @@ function cache(scope, ds, name, optype, field, counts, index) {
       : {field: scope.fieldRef(field), pulse: ref(ds.output)};
     if (sort) params.sort = scope.sortRef(counts);
     op = scope.add(entry(optype, undefined, params));
-    if (index) ds.index[field] = op;
+    if (index) ds[index][field] = op;
     v = ref(op);
     if (k != null) cache[k] = v;
   }
@@ -127,9 +132,9 @@ prototype.valuesRef = function(scope, field, sort) {
 };
 
 prototype.lookupRef = function(scope, field) {
-  return cache(scope, this, 'lookup', 'TupleIndex', field, false);
+  return cache(scope, this, 'lookups', 'TupleIndex', field, false, LOOKUP);
 };
 
 prototype.indataRef = function(scope, field) {
-  return cache(scope, this, 'indata', 'TupleIndex', field, true, true);
+  return cache(scope, this, 'indata', 'TupleIndex', field, true, INDEX);
 };

--- a/src/Scope.js
+++ b/src/Scope.js
@@ -1,4 +1,4 @@
-import DataScope from './DataScope';
+import {default as DataScope, INDEX_TYPES} from './DataScope';
 import {
   aggrField, Ascending, compareRef, Entry,
   fieldRef, keyRef, isSignal, operator, ref
@@ -132,9 +132,13 @@ prototype.finish = function() {
     annotate(ds.input,  name, 'input');
     annotate(ds.output, name, 'output');
     annotate(ds.values, name, 'values');
-    for (var field in ds.index) {
-      annotate(ds.index[field], name, 'index:' + field);
-    }
+
+    INDEX_TYPES.forEach(function(type) {
+      var idx = ds[type];
+      for (var field in idx) {
+        annotate(idx[field], name, type + ':' + field);
+      }
+    });
   }
 
   return this;


### PR DESCRIPTION
This is a work-in-progress PR to initiate code review on my approach before I go too far down the wrong path. 

**Changes Proposed**
* `lookupRef` `TupleIndex` operators stored and annotated as `lookup` (alongside `index` for `indataRef`). 
* An `inIntervalSelection(name, unit, datum, resolve)` expression function to test for inclusion within a Vega-Lite interval selection. 
* An `inPointSelection(name, unit, datum, fields, resolve)` expression function to test for inclusion within a Vega-Lite point (single/multi) selection.

**Questions**
1. The indenting style of `codegen.js` is non-standard to me (function bodies indented by 4 rather than 2, and closing braces indented by 2 rather than being flush against the header). I wanted to double check this was intentional, as it repeatedly confused my text editor.
2. I was not able to find any test cases for functions defined in `codegen.js`? Seems worth investing some time here given the increased surface area of this module and the higher-level dependencies?