### PR TITLE
Stringify object before logging it

### DIFF
--- a/src/parsers/scale.js
+++ b/src/parsers/scale.js
@@ -52,7 +52,7 @@ export default function(spec, scope) {
 function parseLiteral(v, scope) {
   return !isObject(v) ? v
     : v.signal ? scope.signalRef(v.signal)
-    : error('Unsupported object: ' + v);
+    : error('Unsupported object: ' + JSON.stringify(v));
 }
 
 // -- SCALE DOMAIN ----


### PR DESCRIPTION
Otherwise we get `Unsupported object: [object Object]`