### PR TITLE
Add expression functions to test inclusion within Vega-Lite selections.

### DIFF
--- a/src/parsers/expression/codegen-params.js
+++ b/src/parsers/expression/codegen-params.js
@@ -22,6 +22,7 @@ import indata from './indata';
 import inrange from './inrange';
 import encode from './encode';
 import modify from './modify';
+import {vlPoint, vlInterval} from './selection';
 
 var Literal = 'Literal',
     Identifier = 'Identifier',
@@ -89,7 +90,10 @@ export var extendedFunctions = {
 
   encode: encode,
 
-  modify: modify
+  modify: modify,
+
+  vlPoint: vlPoint,
+  vlInterval: vlInterval
 };
 
 function expressionFunctions(codegen) {

--- a/src/parsers/expression/selection.js
+++ b/src/parsers/expression/selection.js
@@ -1,4 +1,5 @@
 import {field} from 'vega-util';
+import inrange from './inrange';
 
 var INDEPENDENT = 'independent',
     INTERSECT = 'intersect',
@@ -18,12 +19,6 @@ function testPoint(datum, entry) {
   }
 
   return true;
-}
-
-function inrange(value, range) {
-  var r0 = range[0], r1 = range[range.length-1], t;
-  if (r0 > r1) t = r0, r0 = r1, r1 = t;
-  return r0 <= value && value <= r1;
 }
 
 function testInterval(datum, entry) {

--- a/src/parsers/expression/selection.js
+++ b/src/parsers/expression/selection.js
@@ -1,0 +1,74 @@
+import {field} from 'vega-util';
+
+var INDEPENDENT = 'independent',
+    INTERSECT = 'intersect',
+    UNION_OTHERS = 'union_others',
+    INTERSECT_OTHERS = 'intersect_others';
+
+function testPoint(datum, entry) {
+  var fields = entry.fields,
+      values = entry.values,
+      n = fields.length,
+      i = 0;
+
+  for (; i<n; ++i) if (field(fields[i])(datum) !== values[i]) return false;
+  return true;
+}
+
+function inrange(value, range) {
+  var r0 = range[0], r1 = range[range.length-1], t;
+  if (r0 > r1) t = r0, r0 = r1, r1 = t;
+  return r0 <= value && value <= r1;
+}
+
+function testInterval(datum, entry) {
+  var intervals = entry.intervals,
+      n = intervals.length,
+      i = 0;
+
+  for (; i<n; ++i) {
+    if (!inrange(field(intervals[i].field)(datum), intervals[i].extent)) return false;
+  }
+  return true;
+}
+
+function vlSelection(name, unit, datum, resolve, test) {
+  var data = this.context.data[name],
+      entries = data ? data.values.value : [],
+      independent = resolve === INDEPENDENT,
+      intersect = resolve === INTERSECT || resolve === INTERSECT_OTHERS || independent,
+      others = resolve === INTERSECT_OTHERS || resolve === UNION_OTHERS,
+      entry, b, i, n;
+
+  for (i=0, n=entries.length; i<n; ++i) {
+    entry = entries[i];
+
+    // is the selection entry from the current unit?
+    b = unit === entry.unit;
+
+    // perform test if source unit is a valid selection source
+    if (!(others && b || independent && !b)) {
+      b = test(datum, entry);
+
+      // if we find a match and we don't require intersection return true
+      // if we find a miss and we do require intersection return false
+      if (intersect ^ b) return b;
+    }
+  }
+
+  // if intersecting and we made it here, then we saw no misses
+  // if not intersecting, then we saw no matches
+  return intersect;
+}
+
+// Assumes point selection tuples are of the form:
+// {unit: string, fields: array<string>, values: array<*>, }
+export function vlPoint(name, unit, datum, resolve) {
+  return vlSelection.call(this, name, unit, datum, resolve, testPoint);
+}
+
+// Assumes interval selection typles are of the form:
+// {unit: string, intervals: array<{field:string, extent:array<number>}>}
+export function vlInterval(name, unit, datum, resolve) {
+  return vlSelection.call(this, name, unit, datum, resolve, testInterval);
+}

--- a/src/parsers/expression/selection.js
+++ b/src/parsers/expression/selection.js
@@ -8,10 +8,15 @@ var INDEPENDENT = 'independent',
 function testPoint(datum, entry) {
   var fields = entry.fields,
       values = entry.values,
+      $ = entry._$ || (entry._$ = []),
       n = fields.length,
       i = 0;
 
-  for (; i<n; ++i) if (field(fields[i])(datum) !== values[i]) return false;
+  for (; i<n; ++i) {
+    $[i] = $[i] || field(fields[i]);
+    if ($[i](datum) !== values[i]) return false;
+  }
+
   return true;
 }
 
@@ -24,10 +29,11 @@ function inrange(value, range) {
 function testInterval(datum, entry) {
   var intervals = entry.intervals,
       n = intervals.length,
-      i = 0;
+      i = 0, $;
 
   for (; i<n; ++i) {
-    if (!inrange(field(intervals[i].field)(datum), intervals[i].extent)) return false;
+    $ = intervals[i]._$ || (intervals[i]._$ = field(intervals[i].field));
+    if (!inrange($(datum), intervals[i].extent)) return false;
   }
   return true;
 }


### PR DESCRIPTION
This PR replaces #7, with simpler expression functions to test inclusion within Vega-Lite's selections:

* `vlPoint(name, unit, datum resolve)` for single and multi selections
* `vlInterval(name, unit, datum, resolve)` for interval selections

where `resolve` is one of `single`, `independent`, `union`, `intersect`, `union_others`, or `intersect_others`. 

These functions can be tested with the following two specifications respectively:

```json
{
  "schema": {"language": "vega", "version": "3.0"},
  "padding": 10,
  "config": {
    "axis": {
      "tickColor": "#ccc"
    }
  },

  "signals": [
    { "name": "chartSize", "value": 120 },
    { "name": "chartPad", "value": 30 },
    { "name": "chartStep", "update": "chartSize + chartPad" },
    { "name": "width", "update": "chartStep * 4" },
    { "name": "height", "update": "chartStep * 4" },
    {
      "name": "cell", "value": null,
      "on": [
        {
          "events": "@cell:mousemove", "update": "group()"
        }
      ]
    }
  ],

  "data": [
    {
      "name": "iris",
      "url": "data/iris.json"
    },
    {
      "name": "fields",
      "values": ["petalWidth", "petalLength", "sepalWidth", "sepalLength"]
    },
    {
      "name": "cross",
      "source": "fields",
      "transform": [
        { "type": "cross", "as": ["x", "y"] },
        { "type": "formula", "as": "xscale", "expr": "datum.x.data + 'X'" },
        { "type": "formula", "as": "yscale", "expr": "datum.y.data + 'Y'" }
      ]
    },
    {"name": "multi_selection"}
  ],

  "scales": [
    {
      "name": "groupx",
      "type": "band",
      "range": "width",
      "domain": {"data": "fields", "field": "data"}
    },
    {
      "name": "groupy",
      "type": "band",
      "range": [{"signal": "height"}, 0],
      "domain": {"data": "fields", "field": "data"}
    },
    {
      "name": "color",
      "type": "ordinal",
      "domain": {"data": "iris", "field": "species"},
      "range": "category"
    }
  ],

  "legends": [
    {
      "fill": "color",
      "title": "Species",
      "offset": 0,
      "encode": {
        "symbols": {
          "update": {
            "fillOpacity": {"value": 0.5},
            "stroke": {"value": "transparent"}
          }
        }
      }
    }
  ],

  "marks": [
    {
      "name": "cell",
      "type": "group",
      "from": {"data": "cross"},

      "signals": [
        {"name": "width", "update": "chartSize"},
        {"name": "height", "update": "chartSize"},
        {
          "name": "multi_values",
          "on": [
            {
              "events": [{
                "source": "scope",
                "type": "click",
                "filter": ["event.item && event.item.mark.name === 'circle'"]
              }],
              "update": "[datum.species, datum.petalLength]",
              "force": true
            }
          ]
        },
        {
          "name": "multi_tuple",
          "on": [{
            "events": {"signal": "multi_values"},
            "update": "{unit: cell.datum._id, fields: ['species', 'petalLength'], values: multi_values}"
          }]
        },
        {
          "name": "multi_trigger",
          "on": [{
            "events": {"signal": "multi_values"},
            "update": "modify('multi_selection', multi_tuple)"
          }]
        }
      ],

      "encode": {
        "enter": {
          "x": {"scale": "groupx", "field": "x.data"},
          "y": {"scale": "groupy", "field": "y.data"},
          "width": {"signal": "chartSize"},
          "height": {"signal": "chartSize"},
          "fill": {"value": "transparent"},
          "stroke": {"value": "#ddd"}
        }
      },

      "scales": [
        {
          "name": "innerX", "type": "linear",
          "zero": false, "nice": true,
          "domain": {"data": "iris", "field": {"signal": "parent.x.data"}},
          "range": "width"
        },
        {
          "name": "innerY", "type": "linear",
          "zero": false, "nice": true,
          "domain": {"data": "iris", "field": {"signal": "parent.y.data"}},
          "range": "height"
        }
      ],

      "axes": [
        {"orient": "bottom", "scale": "innerX", "tickCount": 5},
        {"orient": "left", "scale": "innerY", "tickCount": 5}
      ],

      "marks": [
        {
          "name": "circle",
          "type": "symbol",
          "from": {"data": "iris"},
          "encode": {
            "enter": {
              "x": {
                "scale": "innerX",
                "field": {"datum": {"parent": "x.data"}}
              },
              "y": {
                "scale": "innerY",
                "field": {"datum": {"parent": "y.data"}}
              },
              "fillOpacity": {"value": 0.5},
              "size": {"value": 36}
            },
            "update": {
              "fill": [
                {"test": "!tuples('multi_selection').length || vlPoint('multi_selection', parent._id, datum, 'union')", "scale": "color", "field": "species"},
                {"value": "grey"}
              ]
            }
          }
        }
      ]
    }
  ]
}
```
```json
{
  "schema": {"language": "vega", "version": "3.0"},
  "padding": 10,
  "config": {
    "axis": {
      "tickColor": "#ccc"
    }
  },

  "signals": [
    { "name": "chartSize", "value": 120 },
    { "name": "chartPad", "value": 30 },
    { "name": "chartStep", "update": "chartSize + chartPad" },
    { "name": "width", "update": "chartStep * 4" },
    { "name": "height", "update": "chartStep * 4" },
    {
      "name": "cell", "value": null,
      "on": [
        {
          "events": "@cell:mousedown", "update": "group()"
        }
      ]
    }
  ],

  "data": [
    {
      "name": "iris",
      "url": "data/iris.json"
    },
    {
      "name": "fields",
      "values": ["petalWidth", "petalLength", "sepalWidth", "sepalLength"]
    },
    {
      "name": "cross",
      "source": "fields",
      "transform": [
        { "type": "cross", "as": ["x", "y"] },
        { "type": "formula", "as": "xscale", "expr": "datum.x.data + 'X'" },
        { "type": "formula", "as": "yscale", "expr": "datum.y.data + 'Y'" }
      ]
    },
    {"name": "brush_selection"}
  ],

  "scales": [
    {
      "name": "groupx",
      "type": "band",
      "range": "width",
      "domain": {"data": "fields", "field": "data"}
    },
    {
      "name": "groupy",
      "type": "band",
      "range": [{"signal": "height"}, 0],
      "domain": {"data": "fields", "field": "data"}
    },
    {
      "name": "color",
      "type": "ordinal",
      "domain": {"data": "iris", "field": "species"},
      "range": "category"
    }
  ],

  "legends": [
    {
      "fill": "color",
      "title": "Species",
      "offset": 0,
      "encode": {
        "symbols": {
          "update": {
            "fillOpacity": {"value": 0.5},
            "stroke": {"value": "transparent"}
          }
        }
      }
    }
  ],

  "marks": [
    {
      "name": "cell",
      "type": "group",
      "from": {"data": "cross"},

      "signals": [
        {"name": "width", "update": "chartSize"},
        {"name": "height", "update": "chartSize"},
        {
          "name": "brush_x", "value": [0, 0],
          "on": [
            {
              "events": [{
                "source": "scope",
                "type": "mousedown",
                "filter": ["!event.item || (event.item && event.item.mark.name !== 'brush')"]
              }],
              "update": "[x(cell), x(cell)]"
            },
            {
              "events": [{
                "source": "window",
                "type": "mousemove",
                "consume": true,
                "between": [
                  {"source": "scope", "type":"mousedown"},
                  {"source": "window","type":"mouseup"}
                ]
              }],
              "update": "[brush_x[0], clamp(x(cell), 0, width)]"
            }
          ]
        },
        {
          "name": "brush_y", "value": [0, 0],
          "on": [
            {
              "events": [{
                 "source": "scope",
                 "type": "mousedown",
                 "filter": ["!event.item || (event.item && event.item.mark.name !== 'brush')"]
               }],
              "update": "[y(cell), y(cell)]"
            },
            {
              "events": [{
                "source": "window",
                "type": "mousemove",
                "consume": true,
                "between": [
                  {"source": "scope", "type":"mousedown"},
                  {"source": "window","type":"mouseup"}
                ]
              }],
              "update": "[brush_y[0], clamp(y(cell), 0, height)]"
            }
          ]
        },
        {
          "name": "brush",
          "update": "[invert('innerX', brush_x), invert('innerY', brush_y)]"
        },
        {
          "name": "brush_tuple",
          "on": [{
            "events": {"signal": "brush"},
            "update": "{unit: cell.datum._id, intervals: [{field: cell.datum.x.data, extent: brush[0]}, {field: cell.datum.y.data, extent: brush[1]}]}"
          }]
        },
        {
          "name": "brush_trigger",
          "on": [{
            "events": {"signal": "brush"},
            "update": "modify('brush_selection', brush_tuple, {unit: brush_tuple['unit']})"
          }]
        }
      ],

      "encode": {
        "enter": {
          "x": {"scale": "groupx", "field": "x.data"},
          "y": {"scale": "groupy", "field": "y.data"},
          "width": {"signal": "chartSize"},
          "height": {"signal": "chartSize"},
          "fill": {"value": "transparent"},
          "stroke": {"value": "#ddd"}
        }
      },

      "scales": [
        {
          "name": "innerX", "type": "linear",
          "zero": false, "nice": true,
          "domain": {"data": "iris", "field": {"signal": "parent.x.data"}},
          "range": "width"
        },
        {
          "name": "innerY", "type": "linear",
          "zero": false, "nice": true,
          "domain": {"data": "iris", "field": {"signal": "parent.y.data"}},
          "range": "height"
        }
      ],

      "axes": [
        {"orient": "bottom", "scale": "innerX", "tickCount": 5},
        {"orient": "left", "scale": "innerY", "tickCount": 5}
      ],

      "marks": [
        {
          "type": "rect",
          "encode": {
            "enter": {
              "fill": {"value": "#eee"}
            },
            "update": {
              "x": {"scale": "innerX", "signal": "brush[0][0]"},
              "x2": {"scale": "innerX", "signal": "brush[0][1]"},
              "y": {"scale": "innerY", "signal": "brush[1][0]"},
              "y2": {"scale": "innerY", "signal": "brush[1][1]"}
            }
          }
        },
        {
          "type": "symbol",
          "from": {"data": "iris"},
          "interactive": false,
          "encode": {
            "enter": {
              "x": {
                "scale": "innerX",
                "field": {"datum": {"parent": "x.data"}}
              },
              "y": {
                "scale": "innerY",
                "field": {"datum": {"parent": "y.data"}}
              },
              "fillOpacity": {"value": 0.5},
              "size": {"value": 36}
            },
            "update": {
              "fill": [
                {"test": "!tuples('brush_selection').length || vlInterval('brush_selection', parent._id, datum, 'union')", "scale": "color", "field": "species"},
                {"value": "grey"}
              ]
            }
          }
        },
        {
          "name": "brush",
          "type": "rect",
          "encode": {
            "enter": {
              "fill": {"value": "transparent"}
            },
            "update": {
              "x": {"scale": "innerX", "signal": "brush[0][0]"},
              "x2": {"scale": "innerX", "signal": "brush[0][1]"},
              "y": {"scale": "innerY", "signal": "brush[1][0]"},
              "y2": {"scale": "innerY", "signal": "brush[1][1]"}
            }
          }
        }
      ]
    }
  ]
}
```