### PR TITLE
Add Role Defaults for Vega-Lite only mark types + Add strokeWidth for line

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -62,9 +62,9 @@ function defaults() {
     },
     
     // role defaults for special mark types in Vega-Lite
-    point: {size: vlDefaultSymbolSize, strokeWidth: vlDefaultSymbolStrokeWidth, shape: 'circle'},
-    circle: {size: vlDefaultSymbolSize, strokeWidth: vlDefaultSymbolStrokeWidth},
-    square: {size: vlDefaultSymbolSize, strokeWidth: vlDefaultSymbolStrokeWidth},
+    point: { size: vlDefaultSymbolSize, strokeWidth: vlDefaultSymbolStrokeWidth, shape: 'circle' },
+    circle: { size: vlDefaultSymbolSize, strokeWidth: vlDefaultSymbolStrokeWidth },
+    square: { size: vlDefaultSymbolSize, strokeWidth: vlDefaultSymbolStrokeWidth },
     
     
     // defaults for axes

--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,9 @@ export default function(userConfig) {
 var defaultColor = '#4c78a8',
     black = "#000",
     gray = '#888',
-    lightGray = '#ddd';
+    lightGray = '#ddd',
+    vlDefaultSymbolSize = 30,
+    vlDefaultSymbolStrokeWidth = 2;
 
 /**
  * Standard configuration defaults for Vega specification parsing.
@@ -58,7 +60,13 @@ function defaults() {
       font: 'sans-serif',
       fontSize: 11
     },
-
+    
+    // role defaults for special mark types in Vega-Lite
+    point: {size: vlDefaultSymbolSize, strokeWidth: vlDefaultSymbolStrokeWidth, shape: 'circle'},
+    circle: {size: vlDefaultSymbolSize, strokeWidth: vlDefaultSymbolStrokeWidth},
+    square: {size: vlDefaultSymbolSize, strokeWidth: vlDefaultSymbolStrokeWidth},
+    
+    
     // defaults for axes
     axis: {
       minExtent: 0,


### PR DESCRIPTION
As discussed the earlier day, this might not be the cleanest solution, but it will simplify the API.
Basically, if we can just add configs here, Vega-Lite's API does not have to output extended config that users need to pass to Vega parser. 

These are all the Vega config that we set inside Vega-Lite*.  
1) Add default configs for VL's point / circle / square
2) Make line's default strokeWidth to 2.  I think this is a reasonable default in general (1 is too thin).  However, if you prefer Vega's config to be very lean (no default strokeWidth) then I understand if you want to reject this PR. 

\* Following Tableau, Vega-Lite previously also makes `text`'s value = "Abc" by default (to make `text` mark visible when the `text` property is not specified.)  However, I feel like this is a bit too much for Vega default, so I am not adding it here.  I think I will just make this default text Voyager's config/theme, but not in Vega-Lite overall.