### PR TITLE
Add functions to materialize Vega-Lite selections as scale domains.

### DIFF
--- a/src/parsers/expression/codegen.js
+++ b/src/parsers/expression/codegen.js
@@ -27,7 +27,7 @@ import {treePath, treeAncestors} from './tree';
 import inrange from './inrange';
 import encode from './encode';
 import modify from './modify';
-import {vlPoint, vlInterval} from './selection';
+import {vlPoint, vlInterval, vlPointDomain, vlIntervalDomain} from './selection';
 
 // Expression function context object
 export var functionContext = {
@@ -114,6 +114,8 @@ expressionFunction('indata', indata, indataVisitor);
 expressionFunction('data', data, dataVisitor);
 expressionFunction('vlPoint', vlPoint, dataVisitor);
 expressionFunction('vlInterval', vlInterval, dataVisitor);
+expressionFunction('vlPointDomain', vlPointDomain, dataVisitor);
+expressionFunction('vlIntervalDomain', vlIntervalDomain, dataVisitor);
 expressionFunction('treePath', treePath, dataVisitor);
 expressionFunction('treeAncestors', treeAncestors, dataVisitor);
 

--- a/src/parsers/expression/selection.js
+++ b/src/parsers/expression/selection.js
@@ -1,4 +1,4 @@
-import {field} from 'vega-util';
+import {field, isDate} from 'vega-util';
 import inrange from './inrange';
 
 var UNION = 'union',
@@ -127,7 +127,7 @@ export function vlPointDomain(name, encoding, field, op) {
     domain.push(value.value);
   }
 
-  return domain;
+  return domain.length ? domain : undefined;
 }
 
 function asc(a, b) { return a-b; }
@@ -172,7 +172,7 @@ export function vlIntervalDomain(name, encoding, field, op) {
     }
   }
 
-  return extents.reduce(function(domain, ext) {
+  var domain = extents.reduce(function(domain, ext) {
     if (!domain.length) return ext;
     if (op === UNION) {
       return unionInterval(ext, domain);
@@ -181,4 +181,9 @@ export function vlIntervalDomain(name, encoding, field, op) {
         enclosesInterval(domain, ext) ? intersectInterval(ext, domain) : [];
     }
   }, []);
+
+  return domain.length &&
+    (isDate(domain[0]) ?
+      domain[0].getTime() !== domain[1].getTime() :
+      domain[0] !== domain[1]) ? domain : undefined;
 }

--- a/src/parsers/expression/selection.js
+++ b/src/parsers/expression/selection.js
@@ -80,13 +80,105 @@ function vlSelection(name, unit, datum, op, scope, test) {
 }
 
 // Assumes point selection tuples are of the form:
-// {unit: string, fields: array<string>, values: array<*>, }
+// {unit: string, encodings: array<string>, fields: array<string>, values: array<*>, }
 export function vlPoint(name, unit, datum, op, scope) {
   return vlSelection.call(this, name, unit, datum, op, scope, testPoint);
 }
 
 // Assumes interval selection typles are of the form:
-// {unit: string, intervals: array<{field:string, extent:array<number>}>}
+// {unit: string, intervals: array<{encoding: string, field:string, extent:array<number>}>}
 export function vlInterval(name, unit, datum, op, scope) {
   return vlSelection.call(this, name, unit, datum, op, scope, testInterval);
+}
+
+/**
+ * Materializes a point selection as a scale domain. With point selections,
+ * we assume that they are projected over a single field or encoding channel.
+ * @param   {string} name - The name of the dataset representing the selection.
+ * @param   {string} [encoding] - A particular encoding channel to materialize.
+ * @param   {string} [field] - A particular field to materialize.
+ * @param   {string} [op='intersect'] - The set operation for combining selections.
+ * One of 'intersect' (default) or 'union'.
+ * @returns {array} An array of values to serve as a scale domain.
+ */
+export function vlPointDomain(name, encoding, field, op) {
+  var data = this.context.data[name],
+      entries = data ? data.values.value : [],
+      units = [], values = {}, domain = [],
+      i = 0, n = entries.length,
+      entry, value, unit;
+
+  for (; i<n; ++i) {
+    entry = entries[i];
+    unit  = entry.unit;
+    value = entry.values[0];
+
+    if (units.indexOf(unit) < 0) units.push(unit);
+    if ((encoding && entry.encodings[0] === encoding) ||
+        (field && entry.fields[0] === field)) {
+      values[value] = values[value] || {value: value, units: []};
+      if (values[value].units.indexOf(unit) < 0) values[value].units.push(unit);
+    }
+  }
+
+  for (var key in values) {
+    value = values[key];
+    if (op !== UNION && value.units.length !== units.length) continue;
+    domain.push(value.value);
+  }
+
+  return domain;
+}
+
+function asc(a, b) { return a-b; }
+
+function enclosesInterval(a, b) { return a[0] <= b[0] && a[1] >= b[1]; }
+
+function unionInterval(a, b) {
+  return [Math.min(a[0], b[0]), Math.max(a[1], b[1])];
+}
+
+function intersectInterval(a, b) {
+  if (a[0] > b[0]) b[0] = a[0];
+  if (a[1] < b[1]) b[1] = a[1];
+  return b;
+}
+
+/**
+ * Materializes an interval selection as a scale domain.
+ * @param   {string} name - The name of the dataset representing the selection.
+ * @param   {string} [encoding] - A particular encoding channel to materialize.
+ * @param   {string} [field] - A particular field to materialize.
+ * @param   {string} [op='intersect'] - The set operation for combining selections.
+ * One of 'intersect' (default) or 'union'.
+ * @returns {array} An array of values to serve as a scale domain.
+ */
+export function vlIntervalDomain(name, encoding, field, op) {
+  var data = this.context.data[name],
+      entries = data ? data.values.value : [],
+      i = 0, n = entries.length,
+      extents = [],
+      entry, m, j, interval;
+
+  for (; i<n; ++i) {
+    entry = entries[i];
+
+    for (j=0, m=entry.intervals.length; j<m; ++j) {
+      interval = entry.intervals[j];
+      if ((encoding && interval.encoding === encoding) ||
+        (field && interval.field === field)) {
+        extents.push(interval.extent.slice(0).sort(asc));
+      }
+    }
+  }
+
+  return extents.reduce(function(domain, ext) {
+    if (!domain.length) return ext;
+    if (op === UNION) {
+      return unionInterval(ext, domain);
+    } else {
+      return enclosesInterval(ext, domain) ? intersectInterval(domain, ext) :
+        enclosesInterval(domain, ext) ? intersectInterval(ext, domain) : [];
+    }
+  }, []);
 }


### PR DESCRIPTION
This PR introduces `vlPointDomain` and `vlIntervalDomain` functions to materialize a selection's dataset ready for use as scale domains. 