### PR TITLE
Modify `open` function to use `sanitize` object

### DIFF
--- a/src/parsers/expression/window.js
+++ b/src/parsers/expression/window.js
@@ -4,7 +4,7 @@ export function open(uri, name) {
   var df = this.context.dataflow;
   if (_window && _window.open) {
     df.loader().sanitize(uri, {context:'open', name:name})
-      .then(function(url) { _window.open(url, name); })
+      .then(function(opt) { _window.open(opt.href, name); })
       .catch(function(e) { df.warn('Open url failed: ' + e); });
   } else {
     df.warn('Open function can only be invoked in a browser.');


### PR DESCRIPTION
Hello!

Looks like when the `sanitize` API was [changed to return an object with `href`](https://github.com/vega/vega-loader/commit/b0a0c4b89e68baeddf09985bbfcf067c47cb76aa), this function was missed in the conversion. This PR should fix that.

Thanks for taking a look!