### PR TITLE
Check lambda existence within its own properties

### DIFF
--- a/src/Scope.js
+++ b/src/Scope.js
@@ -276,7 +276,7 @@ prototype.getSignal = function(name) {
 prototype.signalRef = function(s) {
   if (this.signals[s]) {
     return ref(this.signals[s]);
-  } else if (!this.lambdas[s]) {
+  } else if (!this.lambdas.hasOwnProperty(s)) {  
     this.lambdas[s] = this.add(operator(null));
   }
   return ref(this.lambdas[s]);


### PR DESCRIPTION
The lambdas existence check in Scope.js (line 279) should be done within its own properties. Otherwise it causes issues in the following scenario:

1. Parent Scope defined signal 'a' and 'b', and lambda 'a+b'
2. Child Scope later overrides signal 'a' which evaluates to different values, 
3. Then when we use lambda 'a+b' inside Child scope, it reused the lambda in Parent scope which internally evaluated to outside signal 'a'.