### PR TITLE
Update onEvents schema to allow array of signal/scale listeners.

### DIFF
--- a/schema/on-events.js
+++ b/schema/on-events.js
@@ -1,5 +1,19 @@
 export default {
   "defs": {
+    "listener": {
+      "oneOf": [
+        {"$ref": "#/refs/signal"},
+        {
+          "type": "object",
+          "properties": {
+            "scale": {"type": "string"}
+          },
+          "required": ["scale"]
+        },
+        {"$ref": "#/defs/stream"}
+      ]
+    },
+
     "onEvents": {
       "type": "array",
       "items": {
@@ -10,19 +24,11 @@ export default {
               "events": {
                 "oneOf": [
                   {"$ref": "#/refs/selector"},
-                  {"$ref": "#/refs/signal"},
-                  {
-                    "type": "object",
-                    "properties": {
-                      "scale": {"type": "string"}
-                    },
-                    "required": ["scale"]
-                  },
-                  {"$ref": "#/defs/stream"},
+                  {"$ref": "#/defs/listener"},
                   {
                     "type": "array",
                     "minItems": 1,
-                    "items": {"$ref": "#/defs/stream"}
+                    "items": {"$ref": "#/defs/listener"}
                   }
                 ]
               },


### PR DESCRIPTION
I've verified that an array of signals/scale listeners works correctly with example specs as the parser expects on `events` [to be an array](https://github.com/vega/vega-parser/blob/as/onEventsSchema/src/parsers/update.js#L25).