### PR TITLE
Update modify equality check to deeply test object equality.

### DIFF
--- a/src/parsers/expression/modify.js
+++ b/src/parsers/expression/modify.js
@@ -1,15 +1,24 @@
 import {isTuple} from 'vega-dataflow';
-import {isArray, truthy} from 'vega-util';
+import {isArray, isObject, truthy} from 'vega-util';
 
 function equal(a, b) {
   return a === b || a !== a && b !== b ? true
     : isArray(a) && isArray(b) && a.length === b.length ? equalArray(a, b)
+    : isObject(a) && isObject(b) ? equalObject(a, b)
     : false;
 }
 
 function equalArray(a, b) {
   for (var i=0, n=a.length; i<n; ++i) {
     if (!equal(a[i], b[i])) return false;
+  }
+  return true;
+}
+
+function equalObject(a, b) {
+  var keys = Object.keys(a);
+  for (var i=0, n=keys.length; i<n; ++i) {
+    if (!equal(a[keys[i]], b[keys[i]])) return false;
   }
   return true;
 }


### PR DESCRIPTION
In Vega-Lite, discrete selections over binned domains try to toggle tuples of the form:
`{unit: string, encodings: string[], fields: string[], values: [], bins: object}` where the `bins` property identifies fields/values that should be interpreted as a `[bin_start, bin_end]`. However, the modify equality test fails with such tuples because it maintained strict equality for objects. 