### PR TITLE
Parameterize inrange inclusion testing.

### DIFF
--- a/src/parsers/expression/inrange.js
+++ b/src/parsers/expression/inrange.js
@@ -1,9 +1,13 @@
-export default function(value, range) {
+export default function(value, range, left, right) {
   var r0 = range[0], r1 = range[range.length-1], t;
   if (r0 > r1) {
     t = r0;
     r0 = r1;
     r1 = t;
   }
-  return r0 <= value && value <= r1;
+  left = left === undefined || left;
+  right = right === undefined || right;
+
+  return (left ? r0 <= value : r0 < value) &&
+    (right ? value <= r1 : value < r1);
 }

--- a/src/parsers/expression/selection.js
+++ b/src/parsers/expression/selection.js
@@ -20,7 +20,7 @@ function testPoint(datum, entry) {
     if (isDate(values[i])) values[i] = toNumber(values[i]);
     if (bins && bins[fields[i]]) {
       if (isDate(values[i][0])) values[i] = values[i].map(toNumber);
-      if (!inrange(dval, values[i])) return false;
+      if (!inrange(dval, values[i], true, false)) return false;
     } else if (dval !== values[i]) {
       return false;
     }


### PR DESCRIPTION
Discrete bin selections should test whether points fall within the range `[bin_start, bin_end)`.