### PR TITLE
Multi selections should union within the same unit and intersect across units.

### DIFF
--- a/src/parsers/expression/codegen.js
+++ b/src/parsers/expression/codegen.js
@@ -29,7 +29,7 @@ import {treePath, treeAncestors} from './tree';
 import inrange from './inrange';
 import encode from './encode';
 import modify from './modify';
-import {vlPoint, vlInterval, vlPointDomain, vlIntervalDomain} from './selection';
+import {vlPoint, vlPointDomain, vlMultiVisitor, vlInterval, vlIntervalDomain} from './selection';
 
 // Expression function context object
 export var functionContext = {
@@ -122,9 +122,11 @@ expressionFunction('geoBounds', geoBounds, scaleVisitor);
 expressionFunction('geoCentroid', geoCentroid, scaleVisitor);
 expressionFunction('indata', indata, indataVisitor);
 expressionFunction('data', data, dataVisitor);
-expressionFunction('vlPoint', vlPoint, dataVisitor);
+expressionFunction('vlSingle', vlPoint, dataVisitor);
+expressionFunction('vlSingleDomain', vlPointDomain, dataVisitor);
+expressionFunction('vlMulti', vlPoint, vlMultiVisitor);
+expressionFunction('vlMultiDomain', vlPointDomain, vlMultiVisitor);
 expressionFunction('vlInterval', vlInterval, dataVisitor);
-expressionFunction('vlPointDomain', vlPointDomain, dataVisitor);
 expressionFunction('vlIntervalDomain', vlIntervalDomain, dataVisitor);
 expressionFunction('treePath', treePath, dataVisitor);
 expressionFunction('treeAncestors', treeAncestors, dataVisitor);

--- a/src/parsers/expression/selection.js
+++ b/src/parsers/expression/selection.js
@@ -176,10 +176,11 @@ export function vlPointDomain(name, encoding, field, op) {
     }, {});
 
     values = Object.keys(units).map(function(unit) {
-       return {
+      return {
         unit: unit,
-        value: continuous ? continuousDomain(units[unit], UNION) :
-          discreteDomain(units[unit], UNION)
+        value: continuous
+          ? continuousDomain(units[unit], UNION)
+          : discreteDomain(units[unit], UNION)
       };
     });
   } else {
@@ -220,18 +221,17 @@ export function vlIntervalDomain(name, encoding, field, op) {
   }
 
   values = entries.reduce(function(acc, entry) {
-  var extent = entry.intervals[index].extent,
-      value = discrete
-         ? extent.map(function (d) { return {unit: entry.unit, value: d}; })
-         : {unit: entry.unit, value: extent};
+    var extent = entry.intervals[index].extent,
+        value = discrete
+           ? extent.map(function (d) { return {unit: entry.unit, value: d}; })
+           : {unit: entry.unit, value: extent};
 
-     if (discrete) {
-       acc.push.apply(acc, value);
-       return acc;
-     } else {
-       acc.push(value);
-       return acc;
-     }
+    if (discrete) {
+      acc.push.apply(acc, value);
+    } else {
+      acc.push(value);
+    }
+    return acc;
   }, []);
 
 


### PR DESCRIPTION
This PR fixes #55. The `point` selection functions have been broken up into separate `single` and `multi` functions. If a `multi` function is called with an `intersect` parameter, an index is built on the selection store over the `unit` field. 

The predicate function uses this index to conduct inclusion testing. If we've missed against all selections in the current unit, return false; otherwise keep testing. The materialization function first materializes each unit's selection and then intersects them overall.