### PR TITLE
add labelFontWeight config

### DIFF
--- a/src/parsers/guides/axis-labels.js
+++ b/src/parsers/guides/axis-labels.js
@@ -33,6 +33,7 @@ export default function(spec, config, userEncode, dataRef, size) {
   addEncode(enter, 'fill', config.labelColor);
   addEncode(enter, 'font', config.labelFont);
   addEncode(enter, 'fontSize', config.labelFontSize);
+  addEncode(enter, 'fontWeight', config.labelFontWeight);
   addEncode(enter, 'limit', config.labelLimit);
 
   encode.exit = exit = {

--- a/src/parsers/guides/legend-gradient-labels.js
+++ b/src/parsers/guides/legend-gradient-labels.js
@@ -17,6 +17,7 @@ export default function(spec, config, userEncode, dataRef) {
   addEncode(enter, 'fill', config.labelColor);
   addEncode(enter, 'font', config.labelFont);
   addEncode(enter, 'fontSize', config.labelFontSize);
+  addEncode(enter, 'fontWeight', config.labelFontWeight);
   addEncode(enter, 'baseline', config.gradientLabelBaseline);
   addEncode(enter, 'limit', config.gradientLabelLimit);
 

--- a/src/parsers/guides/legend-labels.js
+++ b/src/parsers/guides/legend-labels.js
@@ -16,6 +16,7 @@ export default function(spec, config, userEncode, dataRef) {
   addEncode(enter, 'fill', config.labelColor);
   addEncode(enter, 'font', config.labelFont);
   addEncode(enter, 'fontSize', config.labelFontSize);
+  addEncode(enter, 'fontWeight', config.labelFontWeight);
   addEncode(enter, 'limit', config.labelLimit);
 
   encode.exit = {


### PR DESCRIPTION
This adds a config property `labelFontWeight` to be applied to labels. It works the same as `titleFontWeight` implementing #65.

I am not sure if I though about everything and just tested this with my local setup. Please let me know if there is anything I didn't think of.

Last but not least: Thank you so much for this great project and all the work you put into this! It really makes my life better ❤️ 