### PR TITLE
Allow projection properties to be of type object

### DIFF
--- a/src/parsers/projection.js
+++ b/src/parsers/projection.js
@@ -12,8 +12,13 @@ export default function(proj, scope) {
 }
 
 function parseParameter(_, scope) {
-  return isArray(_) ? _.map(function(_) { return parseParameter(_, scope); })
-    : !isObject(_) ? _
-    : _.signal ? scope.signalRef(_.signal)
-    : error('Unsupported parameter object: ' + stringValue(_));
+  if(isArray(_)) {
+    _.map(function(_) { return parseParameter(_, scope); });
+  } else if(isObject(_) || isNumber(_) || isString(_)) {
+    return _;
+  } else if(_.signal) {
+    return scope.signalRef(_.signal);
+  } else {
+    error('Unsupported parameter object: ' + stringValue(_))
+  }
 }

--- a/src/parsers/projection.js
+++ b/src/parsers/projection.js
@@ -19,6 +19,6 @@ function parseParameter(_, scope) {
   } else if(_.signal) {
     return scope.signalRef(_.signal);
   } else {
-    error('Unsupported parameter object: ' + stringValue(_))
+    error('Unsupported parameter object: ' + stringValue(_));
   }
 }


### PR DESCRIPTION
- This PR allows projection properties to be of type object
- As described in the documentation (https://vega.github.io/vega/docs/projections/) the `fit` property can be either an Array or Object
- Fixes https://github.com/vega/vega-parser/issues/71
- I would be happy to add a test for this case, but I failed to extend the util module with `vega-geo` and `vega-transforms` at the same time -> need help

```js
var tape = require('tape'),
    util = require('vega-util'),
    vega = require('vega-dataflow'),
    parse = require('../').parse;

// FIXME: Fails here because it can't extend the util module with transforms and geo at the same time
util.extend(vega.geo, require('vega-geo'));
util.extend(vega.transforms, require('vega-transforms'));

var data = {
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "Point",
        "coordinates": [
          8.547449111938477,
          47.365222618998935
        ]
      }
    }
  ]
};

tape('Parser parses Vega specs with projection using fit property', function(test) {
  var spec = {
    "data": [
      {
        "name": "map",
        "values": [data],
        "format": { "type": "json" },
        "transform": [
          { "type": "geopath", "projection": "projection" }
        ]
      }
    ],
    "projections": [
        {
          "name": "projection",
          "type": "mercator",
          "fit": {},
          "size": [200, 200]
        }
    ]
  };

  var dfs = parse(spec);

  test.equal(dfs.operators.length, 31);

  test.end();
});
```