### PR TITLE
Refactor Selection Expression Functions

### DIFF
--- a/src/parsers/expression/codegen.js
+++ b/src/parsers/expression/codegen.js
@@ -31,7 +31,7 @@ import {data, indata, setdata, dataVisitor, indataVisitor} from './data';
 import {treePath, treeAncestors} from './tree';
 import encode from './encode';
 import modify from './modify';
-import {vlSelectionTest, vlSelectionVisitor, vlPointDomain, vlIntervalDomain} from './selection';
+import {vlSelectionTest, vlSelectionResolve, vlSelectionVisitor} from './selection';
 
 // Expression function context object
 export var functionContext = {
@@ -132,9 +132,7 @@ expressionFunction('geoShape', geoShape, scaleVisitor);
 expressionFunction('indata', indata, indataVisitor);
 expressionFunction('data', data, dataVisitor);
 expressionFunction('vlSelectionTest', vlSelectionTest, vlSelectionVisitor);
-expressionFunction('vlSingleDomain', vlPointDomain, dataVisitor);
-expressionFunction('vlMultiDomain', vlPointDomain, vlSelectionVisitor);
-expressionFunction('vlIntervalDomain', vlIntervalDomain, dataVisitor);
+expressionFunction('vlSelectionResolve', vlSelectionResolve, vlSelectionVisitor);
 expressionFunction('treePath', treePath, dataVisitor);
 expressionFunction('treeAncestors', treeAncestors, dataVisitor);
 

--- a/src/parsers/expression/codegen.js
+++ b/src/parsers/expression/codegen.js
@@ -31,7 +31,7 @@ import {data, indata, setdata, dataVisitor, indataVisitor} from './data';
 import {treePath, treeAncestors} from './tree';
 import encode from './encode';
 import modify from './modify';
-import {vlPoint, vlPointDomain, vlMultiVisitor, vlInterval, vlIntervalDomain} from './selection';
+import {vlSelectionTest, vlSelectionVisitor, vlPointDomain, vlIntervalDomain} from './selection';
 
 // Expression function context object
 export var functionContext = {
@@ -131,11 +131,9 @@ expressionFunction('geoCentroid', geoCentroid, scaleVisitor);
 expressionFunction('geoShape', geoShape, scaleVisitor);
 expressionFunction('indata', indata, indataVisitor);
 expressionFunction('data', data, dataVisitor);
-expressionFunction('vlSingle', vlPoint, dataVisitor);
+expressionFunction('vlSelectionTest', vlSelectionTest, vlSelectionVisitor);
 expressionFunction('vlSingleDomain', vlPointDomain, dataVisitor);
-expressionFunction('vlMulti', vlPoint, vlMultiVisitor);
-expressionFunction('vlMultiDomain', vlPointDomain, vlMultiVisitor);
-expressionFunction('vlInterval', vlInterval, dataVisitor);
+expressionFunction('vlMultiDomain', vlPointDomain, vlSelectionVisitor);
 expressionFunction('vlIntervalDomain', vlIntervalDomain, dataVisitor);
 expressionFunction('treePath', treePath, dataVisitor);
 expressionFunction('treeAncestors', treeAncestors, dataVisitor);


### PR DESCRIPTION
All Vega-Lite selections now maintain the same state in their corresponding datasets. This state uses tuples of the form:

```
{unit: string, fields: array<fielddef>, values: array<*>}.
```

where `fielddef` is an object of the form:

```
{field: string, channel: string, type: 'E' | 'R' | ... }
```
A `fielddef`'s `type` identifies whether the values being stored are simple enumerations (`E`) or represent ranges (`R`) of different kinds (e.g., a right-exclusive range would be `R-RE`). 

A common selection state has allowed us to simplify the predicate test functions and add a function to resolve selections more efficiently (and with less complex code) than the previous `Domain` functions.

It's as yet unclear to me whether there's logic here that can be extracted or generalized beyond Vega-Lite selections, but I'm open to ideas and to make further modifications to the selection state representation. 

Note: This PR introduces **breaking changes** as the old selection-specific test/domain functions have been removed and replaced with common ones.

I've marked this PR as a WIP until I've had a chance to test the refactoring more thoroughly. But, it's ready for at least high-level feedback. 